### PR TITLE
feat(coin): add 04-lv1-coin-flip (Lv1, Rust)

### DIFF
--- a/04-lv1-coin-flip_rs/README.md
+++ b/04-lv1-coin-flip_rs/README.md
@@ -1,0 +1,48 @@
+# coin-flip  (04-lv1-coin-flip_rs)
+
+## メタ情報
+- **Date**: 2025-09-16
+- **Language**: rs
+- **Level**: Lv1
+- **Environment**: WSL Ubuntu 22.04 / Windows 11
+- **How to Run**:
+  - Build: `mkdir -p bin && rustc src/main.rs -O -o bin/coin-flip`
+  - Run  : `./bin/coin-flip`
+
+## プログラム概要
+コインの表裏（heads/tails）を当てるコンソールゲーム。入力は `h` / `t`（`q` で終了）。勝率を逐次表示。
+
+## 今回の学習テーマ
+- **アルゴリズム**: 乱数での二値選択・簡易スコアリング
+- **言語機能**: 標準入出力、文字列処理、ループ、時刻由来シード
+- **補足**: クレート不要にするため、簡易な XorShift64 で乱数を生成
+
+## 設計メモ（要点）
+- プロンプトを `print!` + `flush()` で明示的にフラッシュ
+- 入力バリデーション：`h/t/q` 以外はリトライ（試行回数には数えない）
+- 勝率は `wins / tries * 100` を小数1桁で表示
+
+## 実行例
+```
+
+Coin Flip (heads/tails). Type 'q' to quit
+
+> guess (h/t): h
+> you: h / coin: tails -> LOSE
+> score: 0/1 (0.0%)
+> guess (h/t): t
+> you: t / coin: tails -> WIN
+> score: 1/2 (50.0%)
+> guess (h/t): q
+> bye! score: 1/2 (50.0%)
+
+```
+
+## GPT活用の要点
+- **日時**: 2025-09-16
+- **相談内容**: Lv1向けの最小構成・外部クレート無しの乱数
+- **役立った回答の要旨**: XorShiftの採用と入出力の最小パターン
+- **採用/却下した提案**: Cargo 初期化は今回は見送り（単一ファイル運用）
+
+## 参考
+- なし

--- a/04-lv1-coin-flip_rs/src/main.rs
+++ b/04-lv1-coin-flip_rs/src/main.rs
@@ -1,0 +1,80 @@
+use std::io::{self, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct XorShift64 {
+    state: u64,
+}
+impl XorShift64 {
+    fn new(seed: u64) -> Self {
+        // seed が 0 のときの固定値（適当な奇数）
+        let s = if seed == 0 { 0x9E37_79B9_7F4A_7C15 } else { seed };
+        Self { state: s }
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+    fn next_bool(&mut self) -> bool {
+        (self.next_u64() & 1) == 1
+    }
+}
+
+fn main() {
+    println!("Coin Flip (heads/tails). Type 'q' to quit");
+
+    // 時刻からシード生成
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
+    let mut rng = XorShift64::new(nanos);
+
+    let mut wins: u32 = 0;
+    let mut tries: u32 = 0;
+
+    loop {
+        print!("> guess (h/t): ");
+        io::stdout().flush().ok();
+
+        let mut s = String::new();
+        if io::stdin().read_line(&mut s).is_err() {
+            println!("bye!");
+            break;
+        }
+        let g = s.trim().to_lowercase();
+        if g == "q" || g == "quit" || g == "exit" {
+            println!("bye! score: {}/{} ({:.1}%)",
+                     wins, tries,
+                     if tries > 0 { wins as f64 / tries as f64 * 100.0 } else { 0.0 });
+            break;
+        }
+
+        let guess = match g.as_str() {
+            "h" | "head" | "heads" => Some(true),
+            "t" | "tail" | "tails" => Some(false),
+            _ => None,
+        };
+        if guess.is_none() {
+            println!("please type 'h' (heads), 't' (tails) or 'q' to quit");
+            continue;
+        }
+
+        let is_heads = rng.next_bool();
+        let actual = if is_heads { "heads" } else { "tails" };
+        let correct = (guess.unwrap() && is_heads) || (!guess.unwrap() && !is_heads);
+
+        tries += 1;
+        if correct {
+            wins += 1;
+            println!("you: {} / coin: {} -> WIN", g, actual);
+        } else {
+            println!("you: {} / coin: {} -> LOSE", g, actual);
+        }
+        let pct = wins as f64 / tries as f64 * 100.0;
+        println!("score: {}/{} ({:.1}%)", wins, tries, pct);
+    }
+}


### PR DESCRIPTION
## Summary
- 04-lv1-coin-flip_rs を追加（Lv1, Rust）
- 外部クレート無し（単一ファイル、`rustc` でビルド）
- XorShift64 による軽量乱数で heads/tails を生成

## How to run
```bash
mkdir -p 04-lv1-coin-flip_rs/bin
rustc 04-lv1-coin-flip_rs/src/main.rs -O -o 04-lv1-coin-flip_rs/bin/coin-flip
./04-lv1-coin-flip_rs/bin/coin-flip
````

## Verification (manual)

実行例：

```
Coin Flip (heads/tails). Type 'q' to quit
> guess (h/t): h
you: h / coin: tails -> LOSE
score: 0/1 (0.0%)
> guess (h/t): q
bye! score: 0/1 (0.0%)
```

## Implementation notes

* 入力は `h`/`t`/`q` を受け付け、プロンプトは `flush()` で即時表示
* 勝率を都度表示（小数1桁）
* `.gitignore` により `**/bin/` は追跡対象外

## Checklist
- [x] 実行確認
- [x] README更新
- [x] 余計なファイルを含まない（.gitignore）
